### PR TITLE
Add functionality to test dbt project in CI. 

### DIFF
--- a/.github/workflows/cleanup-tests.yml
+++ b/.github/workflows/cleanup-tests.yml
@@ -1,0 +1,35 @@
+name: cleanup-tests
+on:
+  pull_request:
+    types:
+      - closed
+
+env:
+  DBT_PROFILES_DIR: transform/ci
+  DBT_RAW_DB: RAW_DDRC_PRD
+  DBT_ANALYTICS_DB: ANALYTICS_DDRC_DEV
+  SNOWFLAKE_PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_DEV }}
+  SNOWFLAKE_USER: ${{ SECRETS.SNOWFLAKE_USER_DEV }}
+  SNOWFLAKE_ACCOUNT: ${{ SECRETS.SNOWFLAKE_ACCOUNT }}
+  SNOWFLAKE_ROLE: TRANSFORMER_DDRC_DEV
+  SNOWFLAKE_WAREHOUSE: TRANSFORMING_XS_DDRC_DEV
+  SNOWFLAKE_DATABASE: TRANSFORM_DDRC_DEV
+  SNOWFLAKE_SCHEMA: GH_CI_PR_${{ github.event.number }}
+
+jobs:
+  cleanup-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+      - name: Install dependencies
+        run: poetry install --no-root
+      - name: Cleanup after tests
+        run: |
+          poetry run python -m jobs.utils.drop_schemas_with_prefix $SNOWFLAKE_DATABASE $SNOWFLAKE_SCHEMA
+          poetry run python -m jobs.utils.drop_schemas_with_prefix $DBT_ANALYTICS_DB $SNOWFLAKE_SCHEMA

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,29 +7,26 @@ on:
 
 env:
   DBT_PROFILES_DIR: ci
-
+  DBT_RAW_DB: RAW_DDRC_PRD
   SNOWFLAKE_PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_DEV }}
   SNOWFLAKE_USER: ${{ SECRETS.SNOWFLAKE_USER_DEV }}
   SNOWFLAKE_ACCOUNT: ${{ SECRETS.SNOWFLAKE_ACCOUNT }}
-defaults:
-  run:
-    shell: bash -l {0}
+  SNOWFLAKE_ROLE: READER_DDRC_DEV
+  SNOWFLAKE_WAREHOUSE: REPORTER_XS_DDRC_DEV
+  SNOWFLAKE_DATABASE: TRANSFORM_DDRC_DEV
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: false
       - name: Install dependencies
         run: |
-          poetry install
+          poetry install --no-root
       - name: Install dbt deps
         run: poetry run dbt deps --project-dir transform
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: tests
+on: pull_request
+
+env:
+  DBT_PROFILES_DIR: transform/ci
+  DBT_RAW_DB: RAW_DDRC_PRD
+  SNOWFLAKE_PRIVATE_KEY: ${{ SECRETS.SNOWFLAKE_PRIVATE_KEY_DEV }}
+  SNOWFLAKE_USER: ${{ SECRETS.SNOWFLAKE_USER_DEV }}
+  SNOWFLAKE_ACCOUNT: ${{ SECRETS.SNOWFLAKE_ACCOUNT }}
+  SNOWFLAKE_ROLE: TRANSFORMER_DDRC_DEV
+  SNOWFLAKE_WAREHOUSE: TRANSFORMING_XS_DDRC_DEV
+  SNOWFLAKE_DATABASE: TRANSFORM_DDRC_DEV
+  SNOWFLAKE_SCHEMA: GH_CI_PR_${{ github.event.number }}
+
+jobs:
+  build-models:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+      - name: Install dependencies
+        run: poetry install --no-root
+      - name: Build dbt project
+        run: |
+          poetry run dbt deps --project-dir transform
+          poetry run dbt build --project-dir transform

--- a/jobs/utils/drop_schemas_with_prefix.py
+++ b/jobs/utils/drop_schemas_with_prefix.py
@@ -1,0 +1,35 @@
+import snowflake.connector
+
+from jobs.utils.snowflake import snowflake_connection_from_environment
+
+
+def drop_schemas_with_prefix(
+    conn: snowflake.connector.SnowflakeConnection, database: str, prefix: str
+) -> None:
+    """
+    Clean up schemas starting with a given prefix.
+
+    Given a Snowflake connection, a database, and a prefix, drop all schemas
+    in the database starting with the prefix.
+
+    This is intended to clean up dev schemas created by dbt.
+    """
+    r = conn.cursor().execute(
+        f"""SHOW TERSE SCHEMAS IN DATABASE "{database}" STARTS WITH '{prefix}'"""
+    )
+    results = r.fetchall()
+
+    for s in results:
+        name = s[1]
+        print(f"Dropping {database}.{name}")
+        conn.cursor().execute(f'''DROP SCHEMA IF EXISTS "{database}"."{name}"''')
+
+
+if __name__ == "__main__":
+    import sys
+
+    database = sys.argv[1]
+    prefix = sys.argv[2]
+
+    conn = snowflake_connection_from_environment()
+    drop_schemas_with_prefix(conn, database, prefix)

--- a/transform/ci/profiles.yml
+++ b/transform/ci/profiles.yml
@@ -7,19 +7,19 @@ caldata_ddrc_pipelines:
       account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('SNOWFLAKE_USER') }}"
       private_key: "{{ env_var('SNOWFLAKE_PRIVATE_KEY') }}"
-      role: READER_DDRC_DEV
-      warehouse: REPORTING_XS_DDRC_DEV
-      database: ANALYTICS_DDRC_DEV
-      schema: ci_should_not_create_this_schema
-      threads: 4
+      role: "{{ env_var('SNOWFLAKE_ROLE') }}"
+      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE') }}"
+      database: "{{ env_var('SNOWFLAKE_DATABASE') }}"
+      schema: "{{ env_var('SNOWFLAKE_SCHEMA', 'ci_should_not_create_this_schema') }}"
+      threads: 8
     prd:
       type: snowflake
 
       account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('SNOWFLAKE_USER') }}"
       private_key: "{{ env_var('SNOWFLAKE_PRIVATE_KEY') }}"
-      role: READER_DDRC_PRD
-      warehouse: REPORTING_XS_DDRC_PRD
-      database: ANALYTICS_DDRC_PRD
-      schema: ANALYTICS
-      threads: 4
+      role: "{{ env_var('SNOWFLAKE_ROLE') }}"
+      warehouse: "{{ env_var('SNOWFLAKE_WAREHOUSE') }}"
+      database: "{{ env_var('SNOWFLAKE_DATABASE') }}"
+      schema: "{{ env_var('SNOWFLAKE_SCHEMA', 'ANALYTICS') }}"
+      threads: 8


### PR DESCRIPTION
The "tests" job runs `dbt build` in the test environment, while the `cleanup-tests` job removes dev schemas after a PR is merged or closed