### PR TITLE
Update EPA schema name

### DIFF
--- a/transform/models/_sources.yml
+++ b/transform/models/_sources.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: EPA
     database: RAW_DDRC_PRD
-    schema: EPA
+    schema: EPA_AGOL_ASSESSMENT
     description: Unknown.
     tables:
       - name: PUBLIC_STATUS_ASSESSMENT


### PR DESCRIPTION
Follow-up to #23 . This updates the EPA schema name to follow new naming convention of `{steward}_{system}_{domain}`