### PR TITLE
metrics definitions and name changes

### DIFF
--- a/transform/models/marts/summary/ddrc_metrics_summary.sql
+++ b/transform/models/marts/summary/ddrc_metrics_summary.sql
@@ -11,12 +11,11 @@ with epa_count_phase1_complete as (
         'count' as metric_type,
         'cleanups completed' as metric_unit_label,
         'Daily' as update_frequency, --acceptable values for this field are 'As needed', 'Daily', 'Weekly', or 'Monthly'
-        last_updated
+        max(last_updated) as last_updated
     from {{ ref('public_status_by_land_use_and_fire_name_counted') }}
     where
-        public_status = 'Phase 1 Complete'
+        public_status in ('Phase 1 Complete', 'Deferred to Phase 2')
         and land_use = 'Residential'
-    group by public_status, last_updated
 ),
 
 usace_parcel_debris_metrics as (

--- a/transform/models/marts/usace/usace__dashboard_metrics.sql
+++ b/transform/models/marts/usace/usace__dashboard_metrics.sql
@@ -7,7 +7,7 @@ with usace as (
 
 roe_status as (
     select
-        'roes accepted' as metric_name,
+        'phase2_roes_accepted' as metric_name,
         'TK' as metric_unit_label,
         count(distinct object_id) as metric_value,
         last_updated
@@ -18,7 +18,7 @@ roe_status as (
 
 in_queue as (
     select
-        'in queue with contractors' as metric_name,
+        'phase2_parcels_in_queue' as metric_name,
         'TK' as metric_unit_label,
         count(distinct object_id) as metric_value,
         last_updated
@@ -30,7 +30,7 @@ in_queue as (
 
 fso_return as (
     select
-        'fso package returned' as metric_name,
+        'phase2_parcels_completed' as metric_name,
         'TK' as metric_unit_label,
         count(distinct object_id) as metric_value,
         last_updated


### PR DESCRIPTION
making these edits per @matthewzhou  

- The cleanups_phase1_complete metric is now correctly coming from US EPA API. One tweak requested here is that we would like this value to be the sum of the Phase 1 Complete +  Deferred to Phase 2 residential property totals. This reflects US EPA's operating logic of calling both of those statuses "complete" - this is how they are evaluating that they are 99% done with Phase 1.
- I see phase 2 metrics now coming through to the JSON blob. I think it's okay to let the metrics flow through into the JSON file for now, and CDT will parse those values out once they have the content PR incorporating these Phase 2 metrics submitted by Jon. Can we rename these metric names for Phase 2 to the following for easier linkage to front end language?
roes accepted -> phase2_roes_accepted
in queue with contractors -> phase2_parcels_in_queue
fso package returned -> phase2_parcels_completed