### PR TITLE
More UTC work

### DIFF
--- a/transform/models/intermediate/epa/int_epa__most_recent_public_status_assessment.sql
+++ b/transform/models/intermediate/epa/int_epa__most_recent_public_status_assessment.sql
@@ -10,7 +10,7 @@ most_recent_psa_data as (
         public_status,
         land_use,
         fire_name,
-        last_updated
+        convert_timezone('UTC', last_updated) as last_updated
     from psa
     where load_date = (select max(load_date) from psa)
 )

--- a/transform/models/intermediate/usace/int_usace__most_recent_debris_removal.sql
+++ b/transform/models/intermediate/usace/int_usace__most_recent_debris_removal.sql
@@ -17,7 +17,7 @@ most_recent_pdr_data as (
         fso_pkg_returned,
         object_id,
         _load_date,
-        last_updated
+        convert_timezone('UTC', last_updated) as last_updated
 
     from pdr
     where last_updated = (select max(last_updated) from pdr)


### PR DESCRIPTION
Make sure AGOL layers are in UTC as well. The specific offset may be controlled by whatever timezone the Snowflake session that initially created the table is.

I don't think this makes a huge difference, as long as the offset in the unloaded stamp is correct, but this keeps things more uniform.

Maybe we could create a data test for checking that all of the timestamps are UTC? Seems hard to enforce otherwise, as Snowflake allows for heterogeneous tz offsets in a timestamp column.