### PR TITLE
remove phase 2 parcels completed metric

### DIFF
--- a/transform/models/marts/usace/usace__dashboard_metrics.sql
+++ b/transform/models/marts/usace/usace__dashboard_metrics.sql
@@ -27,7 +27,7 @@ in_queue as (
     group by all
 
 ),
-
+/* removing this metric per Jason's request 2/28
 fso_return as (
     select
         'phase2_parcels_completed' as metric_name,
@@ -39,13 +39,15 @@ fso_return as (
     group by all
 ),
 
+*/
+
 usace_dashboard_metrics as (
 
     select * from roe_status
     union all
     select * from in_queue
-    union all
-    select * from fso_return
+-- union all
+-- select * from fso_return
 
 )
 


### PR DESCRIPTION
Per Slack conversation with Jason, need to remove one of the usace datapoints -- we'll be adding it via Airtable instead of the USACE API for now.

I left the code in, just commented it out, in case we need to add it back in quickly. 