### PR TITLE
removed temporary fix

### DIFF
--- a/transform/models/marts/airtable/airtable__most_recent_metrics.sql
+++ b/transform/models/marts/airtable/airtable__most_recent_metrics.sql
@@ -22,7 +22,7 @@ max_modified as (
 
 select
     metric_machine_name,
-    to_number(sum(metric), 38, 2) as metric,
+    metric,
     metric_type,
     metric_unit_label,
     update_frequency,


### PR DESCRIPTION
I had created a fragile, temporary workaround for a metric data entry error. After reviewing a little closer, I decided to figure out how to change the value to the correct label in Airtable instead. This reverses the temporary fix.