### PR TITLE
Be more defensive around `None` for geometries

### DIFF
--- a/jobs/utils/snowflake.py
+++ b/jobs/utils/snowflake.py
@@ -141,6 +141,7 @@ def gdf_to_snowflake(
 
     """
     import geopandas.array
+    import pandas
     import shapely.ops
     from snowflake.connector.pandas_tools import write_pandas
 
@@ -167,7 +168,11 @@ def gdf_to_snowflake(
             **{
                 name: gdf[name]
                 .make_valid()
-                .apply(lambda s: shapely.ops.orient(s, 1) if not s.is_empty else s)
+                .apply(
+                    lambda s: shapely.ops.orient(s, 1)
+                    if (pandas.notna(s) and not s.is_empty)
+                    else s
+                )
                 for name, dtype in gdf.dtypes.items()
                 if isinstance(dtype, geopandas.array.GeometryDtype)
             }


### PR DESCRIPTION
The USACE geometries were causing problems because of a few new `None` values (example [here](https://github.com/cagov/caldata-ddrc-pipelines/actions/runs/13638862891/job/38123931054#step:7:43)). This is a bit more defensive about those.