### PR TITLE
Revert "Remove public read"

### DIFF
--- a/terraform/modules/s3-marts/s3.tf
+++ b/terraform/modules/s3-marts/s3.tf
@@ -14,6 +14,15 @@ resource "aws_s3_bucket_versioning" "marts" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "marts" {
+  bucket = aws_s3_bucket.marts.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
 # External stage policy
 # https://docs.snowflake.com/en/user-guide/data-load-s3-config-storage-integration#creating-an-iam-policy
 data "aws_iam_policy_document" "marts_external_stage_policy" {
@@ -46,4 +55,28 @@ resource "aws_iam_policy" "marts_external_stage_policy" {
   name        = "${var.prefix}-${var.region}-marts-external-stage-policy"
   description = "Policy allowing read/write for marts bucket"
   policy      = data.aws_iam_policy_document.marts_external_stage_policy.json
+}
+
+data "aws_iam_policy_document" "marts_public_read" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.marts.arn,
+      "${aws_s3_bucket.marts.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "marts_public_read" {
+  bucket = aws_s3_bucket.marts.id
+  policy = data.aws_iam_policy_document.marts_public_read.json
 }


### PR DESCRIPTION
This makes our *dev* stage in S3 public. The prod stage is also public (this is why we can directly load it onto the webpage). If the dev stage is public, we can more easily share draft JSON blobs with external stakeholders.

I waffled on this a bit in the initial implementation, this just reverts the commit that made it private.

