### PR TITLE
Turn of processes flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,5 +51,5 @@ repos:
         description: "Lints sql files with `SQLFluff`"
         types: [sql]
         require_serial: true
-        entry: poetry run sqlfluff fix --show-lint-violations --processes 0 --nocolor --disable-progress-bar --force
+        entry: poetry run sqlfluff fix --show-lint-violations --nocolor --disable-progress-bar
         pass_filenames: true


### PR DESCRIPTION
Turn off processes flag in sqlfluff, as some systems seem to behave oddly, and it's not needed.

Follow-up to #73