### PR TITLE
Update filters for USACE metrics

### DIFF
--- a/transform/models/intermediate/usace/int_usace__most_recent_debris_removal.sql
+++ b/transform/models/intermediate/usace/int_usace__most_recent_debris_removal.sql
@@ -8,6 +8,7 @@ with pdr as (
 most_recent_pdr_data as (
 
     select
+        ma,
         epa_status,
         roe_status,
         roe_approved,
@@ -16,6 +17,7 @@ most_recent_pdr_data as (
         pcr_status,
         fso_pkg_approved,
         object_id,
+        event_sub_name,
         _load_date,
         convert_timezone('UTC', last_updated) as last_updated
 

--- a/transform/models/marts/usace/usace__dashboard_metrics.sql
+++ b/transform/models/marts/usace/usace__dashboard_metrics.sql
@@ -1,6 +1,9 @@
 with usace as (
 
     select * from {{ ref('int_usace__most_recent_debris_removal') }}
+    where
+        event_sub_name in ('Eaton', 'Palisades')
+        and ma = '4856DR-CA-COE-SPD-09'
 
 ),
 

--- a/transform/models/staging/usace/stg_usace__parcel_debris_removal.sql
+++ b/transform/models/staging/usace/stg_usace__parcel_debris_removal.sql
@@ -24,6 +24,7 @@ with pdr as (
         gdb_to_date,
         gdb_from_date,
         "geometry" as geometry,
+        "event_sub_name" as event_sub_name,
         _load_date,
         to_timestamp_tz(_loaded_at) as last_updated
 


### PR DESCRIPTION
USACE added a more options for mission and event_sub_name, now we need to filter on these to get the same numbers as what the USACE AGOL dashboard shows.

Fixes #81 