### PR TITLE
Stop PARCEL_DEBRIS_REMOVAL load

### DIFF
--- a/jobs/load_agol_sources.py
+++ b/jobs/load_agol_sources.py
@@ -27,18 +27,18 @@ datasets: list[dict[str, Any]] = [
         ),
         "merge_on": ["OBJECTID", "_LOAD_DATE"],
     },
-    #{
-    #"schema": "USACE_AGOL_DEBRIS",
-    #"name": "PARCEL_DEBRIS_REMOVAL",
-    #"url": (
-    #"https://jecop-public.usace.army.mil/arcgis/rest/services/"
-    #"USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
-    #),
-    #"merge_on": ["OBJECTID", "_LOAD_DATE"],
-    ## The USACE seems to have some bad SSL settings on their public-facing AGOL.
-    ## A bit concerning...
-    #"verify": False,
-    #},
+    # {
+    # "schema": "USACE_AGOL_DEBRIS",
+    # "name": "PARCEL_DEBRIS_REMOVAL",
+    # "url": (
+    # "https://jecop-public.usace.army.mil/arcgis/rest/services/"
+    # "USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
+    # ),
+    # "merge_on": ["OBJECTID", "_LOAD_DATE"],
+    # The USACE seems to have some bad SSL settings on their public-facing AGOL.
+    # A bit concerning...
+    # "verify": False,
+    # },
 ]
 
 if __name__ == "__main__":

--- a/jobs/load_agol_sources.py
+++ b/jobs/load_agol_sources.py
@@ -28,16 +28,16 @@ datasets: list[dict[str, Any]] = [
         "merge_on": ["OBJECTID", "_LOAD_DATE"],
     },
     #{
-        #"schema": "USACE_AGOL_DEBRIS",
-        #"name": "PARCEL_DEBRIS_REMOVAL",
-        #"url": (
-            #"https://jecop-public.usace.army.mil/arcgis/rest/services/"
-            #"USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
-        #),
-        #"merge_on": ["OBJECTID", "_LOAD_DATE"],
-        ## The USACE seems to have some bad SSL settings on their public-facing AGOL.
-        ## A bit concerning...
-        #"verify": False,
+    #"schema": "USACE_AGOL_DEBRIS",
+    #"name": "PARCEL_DEBRIS_REMOVAL",
+    #"url": (
+    #"https://jecop-public.usace.army.mil/arcgis/rest/services/"
+    #"USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
+    #),
+    #"merge_on": ["OBJECTID", "_LOAD_DATE"],
+    ## The USACE seems to have some bad SSL settings on their public-facing AGOL.
+    ## A bit concerning...
+    #"verify": False,
     #},
 ]
 

--- a/jobs/load_agol_sources.py
+++ b/jobs/load_agol_sources.py
@@ -27,18 +27,18 @@ datasets: list[dict[str, Any]] = [
         ),
         "merge_on": ["OBJECTID", "_LOAD_DATE"],
     },
-#    {
-#        "schema": "USACE_AGOL_DEBRIS",
-#        "name": "PARCEL_DEBRIS_REMOVAL",
-#        "url": (
-#            "https://jecop-public.usace.army.mil/arcgis/rest/services/"
-#            "USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
-#        ),
-#        "merge_on": ["OBJECTID", "_LOAD_DATE"],
-#        # The USACE seems to have some bad SSL settings on their public-facing AGOL.
-#        # A bit concerning...
-#        "verify": False,
-#    },
+    #{
+        #"schema": "USACE_AGOL_DEBRIS",
+        #"name": "PARCEL_DEBRIS_REMOVAL",
+        #"url": (
+            #"https://jecop-public.usace.army.mil/arcgis/rest/services/"
+            #"USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
+        #),
+        #"merge_on": ["OBJECTID", "_LOAD_DATE"],
+        ## The USACE seems to have some bad SSL settings on their public-facing AGOL.
+        ## A bit concerning...
+        #"verify": False,
+    #},
 ]
 
 if __name__ == "__main__":

--- a/jobs/load_agol_sources.py
+++ b/jobs/load_agol_sources.py
@@ -27,18 +27,18 @@ datasets: list[dict[str, Any]] = [
         ),
         "merge_on": ["OBJECTID", "_LOAD_DATE"],
     },
-    {
-        "schema": "USACE_AGOL_DEBRIS",
-        "name": "PARCEL_DEBRIS_REMOVAL",
-        "url": (
-            "https://jecop-public.usace.army.mil/arcgis/rest/services/"
-            "USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
-        ),
-        "merge_on": ["OBJECTID", "_LOAD_DATE"],
-        # The USACE seems to have some bad SSL settings on their public-facing AGOL.
-        # A bit concerning...
-        "verify": False,
-    },
+#    {
+#        "schema": "USACE_AGOL_DEBRIS",
+#        "name": "PARCEL_DEBRIS_REMOVAL",
+#        "url": (
+#            "https://jecop-public.usace.army.mil/arcgis/rest/services/"
+#            "USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
+#        ),
+#        "merge_on": ["OBJECTID", "_LOAD_DATE"],
+#        # The USACE seems to have some bad SSL settings on their public-facing AGOL.
+#        # A bit concerning...
+#        "verify": False,
+#    },
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stop load of PARCEL_DEBRIS_REMOVAL until server side error has been resolved

Unable to load PARCEL_DEBRIS_REMOVAL, due to 500 Server Error: Internal Server Error for url: https://jecop-public.usace.army.mil/arcgis/rest/services/USACE_Debris_Parcels_Southern_California_Public/MapServer/0/query?where=1%3D1&f=geojson&outFields=%2A&resultOffset=0&returnGeometry=true