### PR TITLE
Re-enable USACE loader

### DIFF
--- a/jobs/load_agol_sources.py
+++ b/jobs/load_agol_sources.py
@@ -27,18 +27,18 @@ datasets: list[dict[str, Any]] = [
         ),
         "merge_on": ["OBJECTID", "_LOAD_DATE"],
     },
-    # {
-    #    "schema": "USACE_AGOL_DEBRIS",
-    #    "name": "PARCEL_DEBRIS_REMOVAL",
-    #    "url": (
-    #        "https://jecop-public.usace.army.mil/arcgis/rest/services/"
-    #        "USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
-    #    ),
-    #    "merge_on": ["OBJECTID", "_LOAD_DATE"],
-    #    # The USACE seems to have some bad SSL settings on their public-facing AGOL.
-    #    # A bit concerning...
-    #    "verify": False,
-    # },
+    {
+        "schema": "USACE_AGOL_DEBRIS",
+        "name": "PARCEL_DEBRIS_REMOVAL",
+        "url": (
+            "https://jecop-public.usace.army.mil/arcgis/rest/services/"
+            "USACE_Debris_Parcels_Southern_California_Public/MapServer/0"
+        ),
+        "merge_on": ["OBJECTID", "_LOAD_DATE"],
+        # The USACE seems to have some bad SSL settings on their public-facing AGOL.
+        # A bit concerning...
+        "verify": False,
+    },
     {
         "schema": "PASADENA_AGOL",
         "name": "EATON_FIRE_REBUILD_PERMITS",


### PR DESCRIPTION
Revert "Disable USACE data load, as the Esri dashboard is currently down"

This reverts commit 3359d6f27ff90a26b9b749cf3ee4f58a04592362.