### PR TITLE
Remove "PendingBSReview" from malibu "In Review" metrics

### DIFF
--- a/transform/models/marts/permitting/malibu_permitting_metrics.sql
+++ b/transform/models/marts/permitting/malibu_permitting_metrics.sql
@@ -14,7 +14,7 @@ malibu_rebuild_applications_in_review as (
         'malibu_rebuild_applications_in_review' as metric_name,
         count(*) as metric_value
     from applications
-    where type in ('InPlanning', 'PendingBSReview', 'InBPC')
+    where type in ('InPlanning', 'InBPC')
 ),
 
 malibu_building_permits_issued as (


### PR DESCRIPTION
The request came in to not include PendingBSReview in the "In Review" metric for Malibu